### PR TITLE
[Fix] 고객 조회 시 멤버십등급명, 국가명으로 정렬 가능하게 수정

### DIFF
--- a/src/main/java/org/iot/hotelitybackend/customer/aggregate/CustomerEntity.java
+++ b/src/main/java/org/iot/hotelitybackend/customer/aggregate/CustomerEntity.java
@@ -1,8 +1,11 @@
 package org.iot.hotelitybackend.customer.aggregate;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.hibernate.annotations.Formula;
 import org.iot.hotelitybackend.sales.aggregate.MembershipIssueEntity;
 
 import jakarta.persistence.Column;
@@ -80,9 +83,24 @@ public class CustomerEntity {
 	}
 
 	@OneToMany(mappedBy = "customer")
-	private Set<MembershipIssueEntity> membershipIssues;
+	private List<MembershipIssueEntity> membershipIssues;
 
 
+
+	@Formula(
+		"(SELECT m.membership_level_name "
+			+ "FROM membership_tb m "
+			+ "JOIN membership_issue_tb mi ON m.membership_level_code_pk = mi.membership_level_code_fk "
+			+ "WHERE mi.customer_code_fk = customer_code_pk)"
+	)
+	private String membershipLevelName;
+
+	@Formula(
+		"(SELECT n.nation_name "
+			+ "FROM nationality_tb n "
+			+ "WHERE n.nation_code_pk = nation_code_fk)"
+	)
+	private String nationName;
 
 	public CustomerEntity() {
 

--- a/src/main/java/org/iot/hotelitybackend/customer/aggregate/CustomerSpecification.java
+++ b/src/main/java/org/iot/hotelitybackend/customer/aggregate/CustomerSpecification.java
@@ -16,8 +16,8 @@ public class CustomerSpecification {
 
 	public static Specification<CustomerEntity> equalsMembershipLevelName(String membershipLevelName) {
 		return (root, query, criteriaBuilder) -> {
-			Join<CustomerEntity, MembershipIssueEntity> issueJoin = root.join("membershipIssues");
-			Join<MembershipIssueEntity, MembershipEntity> membershipJoin = issueJoin.join("membership");
+			Join<CustomerEntity, MembershipIssueEntity> issueJoin = root.join("membershipIssues", JoinType.LEFT);
+			Join<MembershipIssueEntity, MembershipEntity> membershipJoin = issueJoin.join("membership", JoinType.LEFT);
 			return criteriaBuilder.equal(membershipJoin.get("membershipLevelName"), membershipLevelName);
 		};
 	}

--- a/src/main/java/org/iot/hotelitybackend/customer/dto/CustomerDTO.java
+++ b/src/main/java/org/iot/hotelitybackend/customer/dto/CustomerDTO.java
@@ -22,5 +22,5 @@ public class CustomerDTO {
 	private String customerGender;
 	private String nationName;
 	private String membershipLevelName;
-	private List<MembershipDTO> memberships;
+
 }

--- a/src/main/java/org/iot/hotelitybackend/customer/repository/CustomerRepository.java
+++ b/src/main/java/org/iot/hotelitybackend/customer/repository/CustomerRepository.java
@@ -3,8 +3,13 @@ package org.iot.hotelitybackend.customer.repository;
 import java.util.List;
 
 import org.iot.hotelitybackend.customer.aggregate.CustomerEntity;
+import org.iot.hotelitybackend.customer.dto.CustomerDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CustomerRepository extends JpaRepository<CustomerEntity, Integer>,
 	JpaSpecificationExecutor<CustomerEntity> {
@@ -14,4 +19,5 @@ public interface CustomerRepository extends JpaRepository<CustomerEntity, Intege
 	CustomerEntity findByCustomerEmail(String address);
 
 	List<CustomerEntity> findAllByCustomerName(String customerName);
+
 }

--- a/src/main/java/org/iot/hotelitybackend/customer/service/CustomerService.java
+++ b/src/main/java/org/iot/hotelitybackend/customer/service/CustomerService.java
@@ -15,6 +15,11 @@ public interface CustomerService {
 		Date customerRegisteredDate, Integer nationCodeFk, String customerGender, String nationName, String customerType,
 		String membershipLevelName, String orderBy, Integer sortBy, Integer pageNum);
 
+	// Map<String, Object> selectCustomersListTest(Integer customerCodePk, String customerName, String customerEmail,
+	// 	String customerPhoneNumber, String customerEnglishName, String customerAddress, Integer customerInfoAgreement, Integer customerStatus,
+	// 	Date customerRegisteredDate, Integer nationCodeFk, String customerGender, String nationName, String customerType,
+	// 	String membershipLevelName, String orderBy, Integer sortBy, Integer pageNum);
+
     SelectCustomerDTO selectCustomerByCustomerCodePk(Integer customerCodePk);
 
 	Map<String, Object> readExcel(Workbook workbook);

--- a/src/main/java/org/iot/hotelitybackend/hotelmanagement/controller/RoomController.java
+++ b/src/main/java/org/iot/hotelitybackend/hotelmanagement/controller/RoomController.java
@@ -45,11 +45,13 @@ public class RoomController {
 		@RequestParam(required = false) String roomCurrentStatus,
 		@RequestParam(required = false) Float roomDiscountRate,
 		@RequestParam(required = false) String roomView,
-		@RequestParam(required = false) Integer roomSubRoomsCount
+		@RequestParam(required = false) Integer roomSubRoomsCount,
+		@RequestParam(required = false) String orderBy,
+		@RequestParam(required = false) Integer sortBy
 	) {
 
 		Map<String, Object> roomListInfo = roomService.selectSearchedRoomsList(
-			pageNum, roomCodePk, branchCodeFk, roomNumber, roomName, roomCurrentStatus, roomDiscountRate, roomView, roomSubRoomsCount);
+			pageNum, roomCodePk, branchCodeFk, roomNumber, roomName, roomCurrentStatus, roomDiscountRate, roomView, roomSubRoomsCount, orderBy, sortBy);
 
 		ResponseVO response = ResponseVO.builder()
 			.data(roomListInfo)
@@ -97,13 +99,15 @@ public class RoomController {
 		@RequestParam(required = false) String roomCurrentStatus,
 		@RequestParam(required = false) Float roomDiscountRate,
 		@RequestParam(required = false) String roomView,
-		@RequestParam(required = false) Integer roomSubRoomsCount
+		@RequestParam(required = false) Integer roomSubRoomsCount,
+		@RequestParam(required = false) String orderBy,
+		@RequestParam(required = false) Integer sortBy
 	) {
 		try {
 
 			// 조회해서 DTO 리스트 가져오기
 			Map<String, Object> roomListInfo = roomService.selectSearchedRoomsList(
-				pageNum, roomCodePk, branchCodeFk, roomNumber, roomName, roomCurrentStatus, roomDiscountRate, roomView, roomSubRoomsCount);
+				pageNum, roomCodePk, branchCodeFk, roomNumber, roomName, roomCurrentStatus, roomDiscountRate, roomView, roomSubRoomsCount, orderBy, sortBy);
 
 			// 엑셀 시트와 파일 만들기
 			Map<String, Object> result = createExcelFile(

--- a/src/main/java/org/iot/hotelitybackend/hotelmanagement/service/RoomService.java
+++ b/src/main/java/org/iot/hotelitybackend/hotelmanagement/service/RoomService.java
@@ -19,7 +19,9 @@ public interface RoomService {
 		String roomCurrentStatus,
 		Float roomDiscountRate,
 		String roomView,
-		Integer roomSubRoomsCount
+		Integer roomSubRoomsCount,
+		String orderBy,
+		Integer sortBy
 	);
 
 	Map<String, Object> modifyRoomInfo(RequestModifyRoom requestModifyRoom, String roomCodePk);

--- a/src/main/java/org/iot/hotelitybackend/sales/aggregate/MembershipEntity.java
+++ b/src/main/java/org/iot/hotelitybackend/sales/aggregate/MembershipEntity.java
@@ -1,5 +1,8 @@
 package org.iot.hotelitybackend.sales.aggregate;
 
+import java.util.List;
+import java.util.Set;
+
 import org.iot.hotelitybackend.customer.aggregate.CustomerEntity;
 
 import jakarta.persistence.*;
@@ -7,11 +10,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "membership_tb")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 public class MembershipEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,4 +37,7 @@ public class MembershipEntity {
 		this.membershipInfo = membershipInfo;
 		this.membershipCriteriaAmount = membershipCriteriaAmount;
 	}
+
+	@OneToMany(mappedBy = "membership")
+	private List<MembershipIssueEntity> membershipIssue;
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 고객 조회 시 멤버십등급명, 국가명으로 정렬 가능하게 수정
- CustomerEntity 에 @Formula 어노테이션이 달린 가상의 필드(실제 customer_tb에는 없는 필드) 작성
- @Formula 어노테이션에 쿼리문 작성(SELECT ~ FROM ~ JOIN ~ ON ~ WHERE ~)

## 관련 이슈
<!---- 아래와 같이 Issue Number 연결 꼭 해주세요! ---->
<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 코드 중간 통합

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
